### PR TITLE
EW-11575: add crypto module

### DIFF
--- a/jest/__mocks__/crypto.js
+++ b/jest/__mocks__/crypto.js
@@ -1,0 +1,31 @@
+//subtle object
+export const mock_crypto_subtle_digest = jest.fn();
+export const mock_crypto_subtle_importKey = jest.fn();
+export const mock_crypto_subtle_encrypt = jest.fn();
+export const mock_crypto_subtle_decrypt = jest.fn();
+export const mock_crypto_subtle_verify = jest.fn();
+
+const Subtle = jest.fn().mockImplementation(() => {
+    return {
+        digest: mock_crypto_subtle_digest,
+        importKey: mock_crypto_subtle_importKey,
+        encrypt: mock_crypto_subtle_encrypt,
+        decrypt: mock_crypto_subtle_decrypt,
+        verify: mock_crypto_subtle_verify
+    };
+});
+
+//crypto object
+export const mock_crypto_getRandomValues = jest.fn();
+
+const Crypto = jest.fn().mockImplementation(() => {
+    return {
+        getRandomValues: mock_crypto_getRandomValues,
+        subtle: new Subtle()
+    }
+});
+export const crypto = new Crypto();
+
+//are not property of either crypto or subtle
+export const mock_pem2ab = jest.fn();
+export const pem2ab = mock_pem2ab;

--- a/jest/edgeworkers/examples/crypto/bundle.json
+++ b/jest/edgeworkers/examples/crypto/bundle.json
@@ -1,0 +1,4 @@
+{
+  "edgeworker-version": "0.1",
+  "description": "crypto tests"
+}

--- a/jest/edgeworkers/examples/crypto/main.js
+++ b/jest/edgeworkers/examples/crypto/main.js
@@ -1,5 +1,5 @@
 import { crypto, pem2ab } from "../../../__mocks__/crypto";
-  
+
 export function onClientRequest(request) {
   //verifying getRandomValues()
   crypto.getRandomValues(new Uint8Array(6));
@@ -9,24 +9,99 @@ export function onClientRequest(request) {
 
   //verifying importKey()
   let raw_key = new Uint8Array([
-    93, 210, 19, 203, 234, 199, 254, 16, 118, 129, 214, 61, 229, 117, 91, 33,
+    93,
+    210,
+    19,
+    203,
+    234,
+    199,
+    254,
+    16,
+    118,
+    129,
+    214,
+    61,
+    229,
+    117,
+    91,
+    33,
   ]);
   let iv = new Uint8Array([
-    237, 234, 45, 119, 168, 16, 178, 26, 14, 182, 253, 39, 79, 181, 180, 219,
+    237,
+    234,
+    45,
+    119,
+    168,
+    16,
+    178,
+    26,
+    14,
+    182,
+    253,
+    39,
+    79,
+    181,
+    180,
+    219,
   ]);
-  crypto.subtle.importKey(
-    "raw",
-    raw_key,
-    { name: "AES-CBC", iv: iv },
-    false,
-    ["encrypt", "decrypt"]
-  );
+
+  crypto.subtle.importKey("raw", raw_key, { name: "AES-CBC", iv: iv }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
 
   //verifying encrypt()
   let input_data_array = new Uint8Array([
-    44, 237, 221, 235, 17, 155, 115, 79, 8, 211, 94, 216, 92, 183, 9, 106, 15,
-    210, 0, 52, 92, 163, 2, 222, 130, 70, 80, 132, 80, 243, 28, 110, 25, 18, 20,
-    98, 63, 51, 5, 136, 72, 206, 212, 46, 255, 220, 131, 188, 133, 109,
+    44,
+    237,
+    221,
+    235,
+    17,
+    155,
+    115,
+    79,
+    8,
+    211,
+    94,
+    216,
+    92,
+    183,
+    9,
+    106,
+    15,
+    210,
+    0,
+    52,
+    92,
+    163,
+    2,
+    222,
+    130,
+    70,
+    80,
+    132,
+    80,
+    243,
+    28,
+    110,
+    25,
+    18,
+    20,
+    98,
+    63,
+    51,
+    5,
+    136,
+    72,
+    206,
+    212,
+    46,
+    255,
+    220,
+    131,
+    188,
+    133,
+    109,
   ]);
   crypto.subtle.encrypt(
     { name: "AES-CBC", iv: iv },

--- a/jest/package-lock.json
+++ b/jest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edgeworkers-jest-mocks",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "edgeworkers-jest-mocks",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.17.8",

--- a/jest/package.json
+++ b/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeworkers-jest-mocks",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Akamai EdgeWorkers Jest mocks",
   "dependencies": {
     "@babel/core": "^7.17.8",

--- a/jest/test/examples/crypto/main.test.js
+++ b/jest/test/examples/crypto/main.test.js
@@ -1,0 +1,159 @@
+import { onClientRequest } from "../../../edgeworkers/examples/crypto/main";
+import Request from "request";
+import {
+  mock_crypto_getRandomValues,
+  mock_crypto_subtle_digest,
+  mock_crypto_subtle_importKey,
+  mock_crypto_subtle_encrypt,
+  mock_crypto_subtle_decrypt,
+  mock_pem2ab,
+  mock_crypto_subtle_verify,
+} from "../../../__mocks__/crypto";
+
+describe("Crypto EW", () => {
+  test("onClientRequest getRandomValues(), digest(), importKey(), encrypt(), decrypt(), pem2ab(), verify()", () => {
+    let requestMock = new Request();
+    onClientRequest(requestMock);
+
+    expect(mock_crypto_getRandomValues).toHaveBeenCalledTimes(1);
+    expect(mock_crypto_getRandomValues).toHaveBeenCalledWith(new Uint8Array(6));
+
+    expect(mock_crypto_subtle_digest).toHaveBeenCalledTimes(1);
+    expect(mock_crypto_subtle_digest).toHaveBeenCalledWith(
+      "SHA-1",
+      new Int32Array(new ArrayBuffer(8))
+    );
+
+    let raw_key = new Uint8Array([
+      93,
+      210,
+      19,
+      203,
+      234,
+      199,
+      254,
+      16,
+      118,
+      129,
+      214,
+      61,
+      229,
+      117,
+      91,
+      33,
+    ]);
+    let iv = new Uint8Array([
+      237,
+      234,
+      45,
+      119,
+      168,
+      16,
+      178,
+      26,
+      14,
+      182,
+      253,
+      39,
+      79,
+      181,
+      180,
+      219,
+    ]);
+    expect(mock_crypto_subtle_importKey).toHaveBeenCalledTimes(2);
+    expect(mock_crypto_subtle_importKey).toHaveBeenCalledWith(
+      "raw",
+      raw_key,
+      { name: "AES-CBC", iv: iv },
+      false,
+      ["encrypt", "decrypt"]
+    );
+
+    let input_data_array = new Uint8Array([
+      44,
+      237,
+      221,
+      235,
+      17,
+      155,
+      115,
+      79,
+      8,
+      211,
+      94,
+      216,
+      92,
+      183,
+      9,
+      106,
+      15,
+      210,
+      0,
+      52,
+      92,
+      163,
+      2,
+      222,
+      130,
+      70,
+      80,
+      132,
+      80,
+      243,
+      28,
+      110,
+      25,
+      18,
+      20,
+      98,
+      63,
+      51,
+      5,
+      136,
+      72,
+      206,
+      212,
+      46,
+      255,
+      220,
+      131,
+      188,
+      133,
+      109,
+    ]);
+
+    expect(mock_crypto_subtle_encrypt).toHaveBeenCalledTimes(1);
+    expect(mock_crypto_subtle_encrypt).toHaveBeenCalledWith(
+      { name: "AES-CBC", iv: iv },
+      "imported_key",
+      input_data_array
+    );
+
+    expect(mock_crypto_subtle_decrypt).toHaveBeenCalledTimes(1);
+    expect(mock_crypto_subtle_decrypt).toHaveBeenCalledWith(
+      { name: "AES-CBC", iv: iv },
+      "imported_key",
+      "encrypted_data"
+    );
+
+    const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+        4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
+        +qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+        kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+        0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+        cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+        mwIDAQAB
+        -----END PUBLIC KEY-----`;
+
+    expect(mock_pem2ab).toHaveBeenCalledTimes(1);
+    expect(mock_pem2ab).toHaveBeenCalledWith(pemEncodedKey);
+
+    expect(mock_crypto_subtle_verify).toHaveBeenCalledTimes(1);
+    expect(mock_crypto_subtle_verify).toHaveBeenCalledWith({ name: "RSASSA-PKCS1-v1_5" },
+    "crypto_key",
+    "base64url_decode_jwsSignature)",
+    "encoded_jwsSigningInput"
+  );
+  });
+});

--- a/mocha/__mocks__/crypto.js
+++ b/mocha/__mocks__/crypto.js
@@ -1,0 +1,39 @@
+const sinon = require("sinon");
+
+//subtle object
+export const mock_crypto_subtle_digest = sinon.stub();
+export const mock_crypto_subtle_importKey = sinon.stub();
+export const mock_crypto_subtle_encrypt = sinon.stub();
+export const mock_crypto_subtle_decrypt = sinon.stub();
+export const mock_crypto_subtle_verify = sinon.stub();
+
+class Subtle {
+  constructor() {
+    this.digest = mock_crypto_subtle_digest;
+    this.importKey = mock_crypto_subtle_importKey;
+    this.encrypt = mock_crypto_subtle_encrypt;
+    this.decrypt = mock_crypto_subtle_decrypt;
+    this.verify = mock_crypto_subtle_verify;
+  }
+}
+
+//crypto object
+export const mock_crypto_getRandomValues = sinon.stub();
+
+class Crypto {
+  constructor() {
+    this.getRandomValues = mock_crypto_getRandomValues;
+    this.subtle = new Subtle();
+  }
+}
+export const crypto = new Crypto();
+
+//are not property of either crypto or subtle
+export const mock_verify_rs256 = sinon.stub();
+export const verify_rs256 = mock_verify_rs256;
+
+export const mock_pem2ab = sinon.stub();
+export const pem2ab = mock_pem2ab;
+
+export const mock_encoding_base64url_decode = sinon.stub();
+export const base64url_decode = mock_encoding_base64url_decode;

--- a/mocha/__mocks__/crypto.js
+++ b/mocha/__mocks__/crypto.js
@@ -29,11 +29,5 @@ class Crypto {
 export const crypto = new Crypto();
 
 //are not property of either crypto or subtle
-export const mock_verify_rs256 = sinon.stub();
-export const verify_rs256 = mock_verify_rs256;
-
 export const mock_pem2ab = sinon.stub();
 export const pem2ab = mock_pem2ab;
-
-export const mock_encoding_base64url_decode = sinon.stub();
-export const base64url_decode = mock_encoding_base64url_decode;

--- a/mocha/edgeworkers/examples/crypto/bundle.json
+++ b/mocha/edgeworkers/examples/crypto/bundle.json
@@ -1,0 +1,4 @@
+{
+  "edgeworker-version": "0.1",
+  "description": "crypto tests"
+}

--- a/mocha/edgeworkers/examples/crypto/main.js
+++ b/mocha/edgeworkers/examples/crypto/main.js
@@ -1,0 +1,81 @@
+import { crypto, pem2ab, base64url_decode } from "../../../__mocks__/crypto";
+
+function verify_rs256(jwsObject, crypto_key) {
+   const jwsSigningInput = jwsObject.split(".").slice(0, 2).join(".");
+   const jwsSignature = jwsObject.split(".")[2];
+
+    return crypto.subtle.verify(
+        { name: "RSASSA-PKCS1-v1_5" },
+         crypto_key,
+         base64url_decode(jwsSignature),
+         new TextEncoder().encode(jwsSigningInput)
+    );
+}
+  
+export function onClientRequest(request) {
+  //verifying getRandomValues()
+  crypto.getRandomValues(new Uint8Array(6));
+
+  //verifying digest()
+  crypto.subtle.digest("SHA-1", new Int32Array(new ArrayBuffer(8)));
+
+  //verifying importKey()
+  let raw_key = new Uint8Array([
+    93, 210, 19, 203, 234, 199, 254, 16, 118, 129, 214, 61, 229, 117, 91, 33,
+  ]);
+  let iv = new Uint8Array([
+    237, 234, 45, 119, 168, 16, 178, 26, 14, 182, 253, 39, 79, 181, 180, 219,
+  ]);
+  let imported_key = crypto.subtle.importKey(
+    "raw",
+    raw_key,
+    { name: "AES-CBC", iv: iv },
+    false,
+    ["encrypt", "decrypt"]
+  );
+    
+  //verifying encrypt()
+  let input_data_array = new Uint8Array([
+    44, 237, 221, 235, 17, 155, 115, 79, 8, 211, 94, 216, 92, 183, 9, 106, 15,
+    210, 0, 52, 92, 163, 2, 222, 130, 70, 80, 132, 80, 243, 28, 110, 25, 18, 20,
+    98, 63, 51, 5, 136, 72, 206, 212, 46, 255, 220, 131, 188, 133, 109,
+  ]);
+  let encrypted_data = crypto.subtle.encrypt(
+    { name: "AES-CBC", iv: iv },
+    imported_key,
+      input_data_array
+  );
+    
+  //verifying decrypt()
+  let decrypted_data = crypto.subtle.decrypt(
+    { name: "AES-CBC", iv: iv },
+    imported_key,
+    encrypted_data
+  );
+  
+  //verifying pem2ab()
+  //importKey() being called as a part of verification.
+  let jwt =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ";
+
+  const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+        4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
+        +qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+        kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+        0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+        cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+        mwIDAQAB
+        -----END PUBLIC KEY-----`;
+
+  let crypto_key = crypto.subtle.importKey(
+    "spki",
+    pem2ab(pemEncodedKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  
+  //verifying verify()
+  verify_rs256(jwt, crypto_key);
+}

--- a/mocha/package-lock.json
+++ b/mocha/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edgeworkers-mocha-mocks",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "edgeworkers-mocha-mocks",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.17.8",

--- a/mocha/package.json
+++ b/mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgeworkers-mocha-mocks",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Akamai EdgeWorkers Mocha mocks",
   "dependencies": {
     "@babel/core": "^7.17.8",

--- a/mocha/test/examples/crypto/main.test.js
+++ b/mocha/test/examples/crypto/main.test.js
@@ -1,0 +1,46 @@
+import { onClientRequest } from "../../../edgeworkers/examples/crypto/main";
+import Request from "request";
+import {
+  mock_crypto_getRandomValues,
+  mock_crypto_subtle_digest,
+  mock_crypto_subtle_importKey,
+  mock_crypto_subtle_encrypt,
+  mock_crypto_subtle_decrypt,
+  mock_pem2ab,
+  mock_crypto_subtle_verify,
+} from "../../../__mocks__/crypto";
+
+const sinon = require("sinon");
+const expect = require("expect.js");
+
+describe("Crypto EW", () => {
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it("onClientRequest getRandomValues(), digest(), importKey(), encrypt(), decrypt(), pem2ab(), verify()", () => {
+    let requestMock = new Request();
+    onClientRequest(requestMock);
+
+    expect(mock_crypto_getRandomValues.callCount).to.be(1);
+    expect(mock_crypto_getRandomValues.calledWith()).to.be(true);
+
+    expect(mock_crypto_subtle_digest.callCount).to.be(1);
+    expect(mock_crypto_subtle_digest.calledWith()).to.be(true);
+
+    expect(mock_crypto_subtle_importKey.callCount).to.be(2);
+    expect(mock_crypto_subtle_importKey.calledWith()).to.be(true);
+
+    expect(mock_crypto_subtle_encrypt.callCount).to.be(1);
+    expect(mock_crypto_subtle_encrypt.calledWith()).to.be(true);
+
+    expect(mock_crypto_subtle_decrypt.callCount).to.be(1);
+    expect(mock_crypto_subtle_decrypt.calledWith()).to.be(true);
+
+    expect(mock_pem2ab.callCount).to.be(1);
+    expect(mock_pem2ab.calledWith()).to.be(true);
+
+    expect(mock_crypto_subtle_verify.callCount).to.be(1);
+    expect(mock_crypto_subtle_verify.calledWith()).to.be(true);
+  });
+});

--- a/mocha/test/examples/crypto/main.test.js
+++ b/mocha/test/examples/crypto/main.test.js
@@ -23,24 +23,81 @@ describe("Crypto EW", () => {
     onClientRequest(requestMock);
 
     expect(mock_crypto_getRandomValues.callCount).to.be(1);
-    expect(mock_crypto_getRandomValues.calledWith()).to.be(true);
+    expect(mock_crypto_getRandomValues.calledWith(new Uint8Array(6))).to.be(
+      true
+    );
 
     expect(mock_crypto_subtle_digest.callCount).to.be(1);
-    expect(mock_crypto_subtle_digest.calledWith()).to.be(true);
+    expect(
+      mock_crypto_subtle_digest.calledWith(
+        "SHA-1",
+        new Int32Array(new ArrayBuffer(8))
+      )
+    ).to.be(true);
+
+    let raw_key = new Uint8Array([
+      93, 210, 19, 203, 234, 199, 254, 16, 118, 129, 214, 61, 229, 117, 91, 33,
+    ]);
+    let iv = new Uint8Array([
+      237, 234, 45, 119, 168, 16, 178, 26, 14, 182, 253, 39, 79, 181, 180, 219,
+    ]);
 
     expect(mock_crypto_subtle_importKey.callCount).to.be(2);
-    expect(mock_crypto_subtle_importKey.calledWith()).to.be(true);
+    expect(
+      mock_crypto_subtle_importKey.calledWith(
+        "raw",
+        raw_key,
+        { name: "AES-CBC", iv: iv },
+        false,
+        ["encrypt", "decrypt"]
+      )
+    ).to.be(true);
+
+    let input_data_array = new Uint8Array([
+      44, 237, 221, 235, 17, 155, 115, 79, 8, 211, 94, 216, 92, 183, 9, 106, 15,
+      210, 0, 52, 92, 163, 2, 222, 130, 70, 80, 132, 80, 243, 28, 110, 25, 18,
+      20, 98, 63, 51, 5, 136, 72, 206, 212, 46, 255, 220, 131, 188, 133, 109,
+    ]);
 
     expect(mock_crypto_subtle_encrypt.callCount).to.be(1);
-    expect(mock_crypto_subtle_encrypt.calledWith()).to.be(true);
+    expect(
+      mock_crypto_subtle_encrypt.calledWith(
+        { name: "AES-CBC", iv: iv },
+        "imported_key",
+        input_data_array
+      )
+    ).to.be(true);
 
     expect(mock_crypto_subtle_decrypt.callCount).to.be(1);
-    expect(mock_crypto_subtle_decrypt.calledWith()).to.be(true);
+    expect(
+      mock_crypto_subtle_decrypt.calledWith(
+        { name: "AES-CBC", iv: iv },
+        "imported_key",
+        "encrypted_data"
+      )
+    ).to.be(true);
+
+    const pemEncodedKey = `-----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+        4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
+        +qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+        kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+        0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+        cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+        mwIDAQAB
+        -----END PUBLIC KEY-----`;
 
     expect(mock_pem2ab.callCount).to.be(1);
-    expect(mock_pem2ab.calledWith()).to.be(true);
+    expect(mock_pem2ab.calledWith(pemEncodedKey)).to.be(true);
 
     expect(mock_crypto_subtle_verify.callCount).to.be(1);
-    expect(mock_crypto_subtle_verify.calledWith()).to.be(true);
+    expect(
+      mock_crypto_subtle_verify.calledWith(
+        { name: "RSASSA-PKCS1-v1_5" },
+        "crypto_key",
+        "base64url_decode_jwsSignature)",
+        "encoded_jwsSigningInput"
+      )
+    ).to.be(true);
   });
 });


### PR DESCRIPTION
Added the following crypto functions to the test framework:

crypto.subtle object:
1. importKey()
2. encrypt()
3. decrypt()
4. verify()
5. digest()

crypto object:
6. getRandomValues()

standalone function:
7. pem2ab()

CLA check is failing, that is expected.
npm tests are passing in both mocha & jest:

```
Test Suites: 32 passed, 32 total
Tests:       65 passed, 65 total
Snapshots:   0 total
Time:        3.441 s, estimated 4 s
Ran all test suites.
avbeh@yow-mpoaz jest % 
```

```
  62 passing (149ms)

avbeh@yow-mpoaz mocha % 
```